### PR TITLE
Add changes from theory-of-heaps-translation-thesis-version

### DIFF
--- a/src/tricera/Main.scala
+++ b/src/tricera/Main.scala
@@ -678,7 +678,7 @@ class Main (args: Array[String]) {
                     printlnDebug(postClauses.toString)
 
                     acslProcessedSolution = addClauses(
-                      postClauses,ctx.prePred.pred, acslProcessedSolution)
+                      postClauses,ctx.postPred.pred, acslProcessedSolution)
                   }
 
                   val printHeapExprProcessors = Seq(

--- a/src/tricera/concurrency/CCReader.scala
+++ b/src/tricera/concurrency/CCReader.scala
@@ -696,7 +696,7 @@ class CCReader private (prog              : Program,
 
   if (modelHeap) {
     GlobalVars addVar heapVar
-    GlobalVars.inits += CCTerm(heap.emptyHeap(), CCHeap(heap), None)
+    GlobalVars.inits += CCTerm(heapTerm, CCHeap(heap), None)
     variableHints += List()
   }
 


### PR DESCRIPTION
This PR adds a few changes from https://github.com/OskarSoderberg/tricera/tree/theory-of-heaps-translation-thesis-version. It fixes a problem with missing `\valid(...)` and `separated(...)` clauses in the contracts